### PR TITLE
Rst 7329

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,9 @@ tmp/**/*
 /public/assets
 /public/apply
 /node_modules
-/public/packs
-/public/packs-test
+/public/vite
+/public/vite-test
+/public/vite-dev
 /coverage
 /.bundle
 /.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN apk add --no-cache libpq-dev tzdata shared-mime-info libc6-compat && \
     apk add --no-cache --virtual .build-tools git build-base curl-dev nodejs yarn && \
     cd /home/app/et3 && \
+    yarn install && \
     gem install bundler && \
     bundle config set without 'test development' && \
     bundle config set with 'assets production' && \

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -9,12 +9,20 @@
     <meta name="theme-color" content="#0b0c0c">
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link  rel="icon" sizes="48x48"  href="<%= asset_path('favicon.ico') %>">
+    <link rel="icon" sizes="any" href="<%= asset_path('favicon.svg') %>" type="image/svg+xml">
+    <link rel="mask-icon" href="<%= asset_path('govuk-icon-mask.svg') %>" color="#0b0c0c">
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-icon-180.png') %>">
+
     <%# the colour used for theme-color is the standard palette $black from
         https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
     <meta name="theme-color" content="#0b0c0c" />
 
     <%= yield :head %>
 
+    <%# The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
+    <meta property="og:image" content="<%= asset_path "govuk-opengraph-image.png" %>">
   </head>
 
   <body class="govuk-template__body <%= content_for?(:body_classes) ? raw("#{yield(:body_classes)}") : '' %>">

--- a/bin/run_full_system
+++ b/bin/run_full_system
@@ -30,5 +30,5 @@ FileUtils.chdir APP_ROOT do
   system! 'bin/rails db:create db:migrate'
 
   puts "\n== Starting app"
-  system! "cd #{APP_ROOT} && invoker start"
+  system! "cd #{APP_ROOT} && invoker start Procfile"
 end


### PR DESCRIPTION
This corrects the root cause of the issue with deployment in production.

The root cause was that there were no node_modules in the docker image in the asset build stage - as yarn was not run.

This means that assets like favicon.ico were not present